### PR TITLE
Convert devgithubproj_/pipelines/pipeline2 to GitHub Actions

### DIFF
--- a/.github/workflows/pipeline2.yml
+++ b/.github/workflows/pipeline2.yml
@@ -1,0 +1,19 @@
+name: devgithubproj_/pipelines/pipeline2
+on:
+  push:
+    branches:
+    - main
+jobs:
+  build:
+    runs-on:
+      - self-hosted
+      - mechamachine
+    steps:
+    - name: checkout
+      uses: actions/checkout@v4.1.0
+    - name: Run a one-line script
+      run: echo Hello, I am pipeline 2!
+    - name: Run a multi-line script
+      run: |-
+        echo Add other tasks to build, test, and deploy your project.
+        echo See https://aka.ms/yaml


### PR DESCRIPTION
Pipeline migrated from [Azure DevOps](https://dev.azure.com/migrategithub/devgithubproj%20/_build?definitionId=9) :tada:

## Manual steps

Perform the following steps to complete the migration:

### devgithubproj /pipelines/pipeline2
- [ ] Ensure a runner with the following labels exists: mechamachine